### PR TITLE
Fix handling of non-json values as parameters

### DIFF
--- a/thoth/analyzer/cli.py
+++ b/thoth/analyzer/cli.py
@@ -50,7 +50,9 @@ def _get_click_arguments(click_ctx: click.core.Command) -> dict:
         for key, value in dict(ctx.params).items():
             # If the given argument was provided as a JSON, parse it so we have structured reports.
             try:
-                value = json.loads(value)
+                parsed_value = json.loads(value)
+                if isinstance(parsed_value, dict):
+                    value = parsed_value
             except Exception:
                 pass
             report[key] = value


### PR DESCRIPTION
Fixes: https://github.com/thoth-station/graph-sync-job/issues/275

This fix addresses issues with arguments parsing - all arguments should be
present as string in the final report. In some cases we did the following
parsing, which caused issues on data ingestion side:

  json.loads("18.0") == 18.0