### PR TITLE
Add Thoth's deployment name to document metadata

### DIFF
--- a/thoth/analyzer/cli.py
+++ b/thoth/analyzer/cli.py
@@ -131,6 +131,7 @@ def print_command_result(click_ctx: click.core.Command,
             'implementation_name': sys.implementation.name
         },
         "os_release": _gather_os_release(),
+        "thoth_deployment_name": os.getenv("THOTH_DEPLOYMENT_NAME"),
     }
 
     content = {


### PR DESCRIPTION
... so that we will know the origin of documents (what deployment was used).