### PR TITLE
No need to have self in to_dict() method

### DIFF
--- a/thoth/analyzer/command.py
+++ b/thoth/analyzer/command.py
@@ -68,7 +68,6 @@ class CommandResult(object):
             "return_code": self.return_code,
             "command": self.command.cmd,
             "timeout": self.timeout,
-            "message": str(self),
         }
 
 


### PR DESCRIPTION
The message is misleading:
```
thamos.discover: Unable to detect CUDA version - nvcc returned non-zero version: {'stdout': '', 'stderr': '/bin/sh: nvcc: command not found\n', 'return_code': 127, 'command': 'nvcc --version', 'timeout': 60, 'message': '<thoth.analyzer.command.CommandResult object at 0x7f004d66df60>'}
```